### PR TITLE
麻将牌JSON解析器(1.14+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+debug.py
+debug_plugin.py
+PlayerInfoAPI_v.py
+temp.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PlayerInfoAPI
 -------------
 
-[中文](#https://github.com/TISUnion/PlayerInfoAPI/blob/master/README_cn.md)
+[中文](https://github.com/TISUnion/PlayerInfoAPI/blob/master/README_cn.md)
 
 a MCDaemon plugin to provide API for getting player information
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # PlayerInfoAPI
 -------------
 
+[中文](#https://github.com/TISUnion/PlayerInfoAPI/blob/master/README_cn.md)
+
 a MCDaemon plugin to provide API for getting player information
 
 Compatible with MCDaemon and MCDReforged
+
+Now support 1.14+ new JSON string format
 
 (Thank Pandaria for providing the regular expression)
 
@@ -35,7 +39,7 @@ Minecraft style json format is something like these:
 It will automatically detect if there is a `<name> has the following entity data: `. If there is, it will erase it before converting
 
 Args:
-- text: A data get entity ot other command result that use Minecraft style json format
+- text: A data get entity or other command result that use Minecraft style json format
 
 Return:
 - a parsed json result

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,0 +1,79 @@
+# PlayerInfoAPI
+-------------
+
+一个提供获取玩家信息API的MCD插件
+
+兼容 MCDaemon 和 MCDReforged
+
+现在支持14.4以上的新JSON字符串格式
+
+(感谢 Pandaria 提供的有关正则表达式的支持)
+
+## 使用方法
+
+你必须先使用 imp.load_source()  来在你的插件中载入PlayerInfoAPI
+
+```
+from imp import load_source
+PlayerInfoAPI = load_source('PlayerInfoAPI','./plugins/PlayerInfoAPI.py')
+```
+
+如果使用 MCDReforged 只需使用 `server.get_plugin_instance()` 来获得 PlayerInfoAPI 插件实例
+
+```
+PlayerInfoAPI = server.get_plugin_instance('PlayerInfoAPI')
+```
+
+### 方法：PlayerInfoAPI.convertMinecraftJson(text)
+
+将麻将牌JSON转换成Python可读取的字典数据类型
+
+麻将牌JSON的形式如下：
+
+- `Steve has the following entity data: [-227.5d, 64.0d, 12.3E4d]`
+- `[-227.5d, 64.0d, 231.5d]`
+- `Alex has the following entity data: {HurtByTimestamp: 0, SleepTimer: 0s, ..., Inventory: [], foodTickTimer: 0}`
+
+会自动检查消息是否包含 `<name> has the following entity data: `前缀，并且会在转换前自动去除
+
+参数：
+- text: 从`/data get entity`指令或者其他命令获得的麻将牌JSON数据
+
+返回：
+- 解析后的结果
+
+示例：
+
+- 输入： `Steve has the following entity data: [-227.5d, 64.0d, 231.5d]`, output `[-227.5, 64.0, 123000.0]`
+
+- 输出： `{HurtByTimestamp: 0, SleepTimer: 0s, Inventory: [], foodTickTimer: 0}`, output `{'HurtByTimestamp': 0, 'SleepTimer': 0, 'Inventory': [], 'foodTickTimer': 0}`
+
+### 方法：PlayerInfoAPI.getPlayerInfo(server, name, path='')
+
+自动执行 `/data get entity <name> [<path>]` 并解析返回数据
+
+如果在 MCDReforged 中使用并且开启了rcon，插件会自动从rcon执行获得结果
+
+参数：
+- server: Server对象
+- name: 要获得TA数据的目标玩家
+- path: 在`/data get entity` 指令中的可选参数`path`
+
+返回：
+ - 解析后的结果
+
+你可以在Minecraft Wiki参考关于Player.det的格式信息
+[Player.dat格式](https://minecraft-zh.gamepedia.com/Player.dat%E6%A0%BC%E5%BC%8F)
+
+## 示例
+
+```
+def onServerInfo(server, info):
+  if info.content.startswith('!!test'):
+    result = PlayerInfoAPI.getPlayerInfo(server,info.player)
+    server.say("Dim:"+str(result["Dimension"])+"Pos:"+str(result["Pos"][0])+","+str(result["Pos"][1])+","+str(result["Pos"][2]))
+```
+
+你也可以参考使用了这个API的插件例子(位于newapi分支)
+
+[Here(Demo)](https://github.com/TISUnion/Here/tree/newapi)


### PR DESCRIPTION
兼容旧版本，返回数据做了兼容处理可以在高低版本通用，低版本不会触发高版本解析相关的处理
性能数据：
处理用时59.285秒/1w次(取三次平均)
传入数据长度：33299个字符长的玩家真实数据
Intel Core(TM) i5-10210U @ 1.60GHz (睿频3.4GHz)
(并更新README)

测试通过：1.13.2 1.14.4 1.15.2
测试时用到的一些奇妙物品名：
琨斤拷"'\/?..
\\\\
////
1//1
1\1
"
'
'{{}}'
'{{{
}}}'
[1,2,3]
{“name":"reeee"}
